### PR TITLE
ENG-159: Install kubernetes autoscaler alongside PremiScale agent

### DIFF
--- a/helm/premiscale/Chart.yaml
+++ b/helm/premiscale/Chart.yaml
@@ -16,3 +16,8 @@ dependencies:
     alias: influxdb
     version: 0.0.x
     condition: influxdb.enabled
+  # - name: autoscaler/cluster-autoscaler
+  #   repository: https://kubernetes.github.io/autoscaler
+  #   alias: kubernetes-autoscaler
+  #   version:
+  #   condition: kubernetesAutoscaler.enabled

--- a/helm/premiscale/values.yaml
+++ b/helm/premiscale/values.yaml
@@ -58,3 +58,7 @@ influxdb:
   enabled: false
 mysql:
   enabled: false
+
+# Deploy the kubernetes autoscaler for PremiScale to connect to.
+kubernetesAutoscaler:
+  enabled: false


### PR DESCRIPTION
ToDos:

- Publish a version of the kubernetes-autoscaler project's Helm chart that supports PremiScale
  - Must reference a version of the autoscaler that implements an interface that the agent can connect or subscribe to.
- Test deployment.