### PR TITLE
fix-influxdb-healthcheck-defaults: healthcheck waits unnecessarily long for container to start

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -81,10 +81,10 @@ services:
           memory: 1G
     healthcheck:
       test: influx ping || exit 1
-      interval: 60s
+      interval: 3s
       retries: 5
-      start_period: 20s
-      timeout: 10s
+      start_period: 5s
+      timeout: 5s
 
   # Platform network
   echoes:
@@ -101,7 +101,7 @@ services:
       - MYSQL_USERNAME=premiscale
       - MYSQL_PASSWORD=premiscale
       - MYSQL_HOST=localhost
-      - MYSQL_PORT=3036
+      - MYSQL_PORT=3037
       - MYSQL_DATABASE=premiscale
     ports:
       - 8080:8080
@@ -138,7 +138,7 @@ services:
       - MYSQL_USERNAME=premiscale
       - MYSQL_PASSWORD=premiscale
       - MYSQL_HOST=localhost
-      - MYSQL_PORT=3036
+      - MYSQL_PORT=3037
       - MYSQL_DATABASE=premiscale
     ports:
       - 8082:8080

--- a/src/premiscale/controller/platform.py
+++ b/src/premiscale/controller/platform.py
@@ -142,7 +142,7 @@ class Platform:
     """
     def __init__(self, url: str, token: str, path: str = '/agent/websocket') -> None:
         # Path needs to align with the Helm chart's ingress.
-        self.url = urljoin('wss://' + url, path)
+        self.url = urljoin('ws://' + url, path)
         self._token = token
         self.websocket = None
         self.queue: Queue


### PR DESCRIPTION
- Containers start very quickly on my local machine, there's no reason to waste local development time .