### PR TITLE
fix-registration-endpoint: wrong path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,4 +75,4 @@ RUN mkdir -p "$HOME"/.local/bin \
     && poetry run premiscale --version
 
 ENTRYPOINT [ "/tini", "--" ]
-CMD [ "bash", "-c", "poetry run premiscale --log-stdout --daemon --cacert=${PREMISCALE_CACERT}" ]
+CMD [ "bash", "-c", "poetry run premiscale --log-stdout --daemon --cacert=${PREMISCALE_CACERT} --platform ${PREMISCALE_PLATFORM}" ]

--- a/src/premiscale/controller/daemon.py
+++ b/src/premiscale/controller/daemon.py
@@ -86,7 +86,7 @@ def start(
                     registration=registration,
                     version=controller_version,
                     host=f'wss://{host}',
-                    path='controller/websocket',
+                    path='agent/websocket',
                     cacert=cacert
                 ),
                 platform_message_queue
@@ -94,7 +94,7 @@ def start(
                 token=token,
                 version=controller_version,
                 host=f'https://{host}',
-                path='controller/registration',
+                path='agent/registration',
                 cacert=cacert
             )) else None,
 

--- a/src/premiscale/controller/platform.py
+++ b/src/premiscale/controller/platform.py
@@ -109,7 +109,7 @@ def register(
         version (str): agent version.
         host (str): platform domain.
         path (str): endpoint to hit at the platform domain.
-        cacert (str): path to the CA certificate file.
+        cacert (str): path to the CA certificate file, if provided.
 
     Returns:
         Dict[str, str] | None: registration service response, or an empty dict if the registration was not successful.


### PR DESCRIPTION
I deleted a bunch of flags in a former PR, so the platform URL was wrong, followed by the path.

```text
...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/premiscale/src/premiscale/controller/cli.py", line 138, in main
    start(
  File "/opt/premiscale/src/premiscale/controller/daemon.py", line 93, in start
    ) if (registration := register(
  File "/opt/premiscale/src/premiscale/controller/platform.py", line 87, in new_f
    while (res := call()) is None:
  File "/opt/premiscale/src/premiscale/controller/platform.py", line 68, in call
    return f(*args, **kwargs)
  File "/opt/premiscale/src/premiscale/controller/platform.py", line 132, in register
    response = requests.post(
  File "/opt/premiscale/.cache/pypoetry/virtualenvs/premiscale-s1FYViBm-py3.10/lib/python3.10/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/opt/premiscale/.cache/pypoetry/virtualenvs/premiscale-s1FYViBm-py3.10/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/opt/premiscale/.cache/pypoetry/virtualenvs/premiscale-s1FYViBm-py3.10/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/premiscale/.cache/pypoetry/virtualenvs/premiscale-s1FYViBm-py3.10/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/opt/premiscale/.cache/pypoetry/virtualenvs/premiscale-s1FYViBm-py3.10/lib/python3.10/site-packages/requests/adapters.py", line 700, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='app.premiscale.com', port=443): Max retries exceeded with url: /controller/registration (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x2aaab5e746a0>: Failed to establish a new connection: [E
rrno 111] Connection refused'))
```